### PR TITLE
Merge request: #78 'Signing' class cannot create old CURL addresses

### DIFF
--- a/jota/src/main/java/jota/utils/Signing.java
+++ b/jota/src/main/java/jota/utils/Signing.java
@@ -132,7 +132,8 @@ public class Signing {
 
     public int[] digest(int[] normalizedBundleFragment, int[] signatureFragment) {
     	ICurl iCurl = this.evaluateDigestCurlObject();
-        ICurl jCurl = this.getICurlObject(SpongeFactory.Mode.KERL);
+    	iCurl.reset();
+    	ICurl jCurl = iCurl.clone();
         int[] buffer = new int[HASH_LENGTH];
 
         for (int i = 0; i < 27; i++) {


### PR DESCRIPTION
The current commit is related to the ticket #78 - 'Signing' class cannot create old CURL addresses. The class Signing.class is modified to allow the use of any kind of ICarl instance and prevent a live lock problem.