### PR TITLE
Proposed changes for getNewAddress to prevent confusion (index reuse)

### DIFF
--- a/jota/src/main/java/jota/IotaAPI.java
+++ b/jota/src/main/java/jota/IotaAPI.java
@@ -73,7 +73,7 @@ public class IotaAPI extends IotaAPICore {
     }
     
     /**
-     * 
+     * Checks all addresses until the first unspent address is found. Starts at index 0.
      * @param seed      Tryte-encoded seed. It should be noted that this seed is not transferred.
      * @param security  Security level to be used for the private key / address. Can be 1, 2 or 3.
      * @param checksum  Adds 9-tryte address checksum.
@@ -85,7 +85,7 @@ public class IotaAPI extends IotaAPICore {
     }
     
     /**
-     * 
+     * Checks all addresses until the first unspent address is found.
      * @param seed      Tryte-encoded seed. It should be noted that this seed is not transferred.
      * @param security  Security level to be used for the private key / address. Can be 1, 2 or 3.
      * @param checksum  Adds 9-tryte address checksum.
@@ -98,7 +98,8 @@ public class IotaAPI extends IotaAPICore {
     }
     
     /**
-     * 
+     * Generates new addresses, meaning addresses which were not spend from, according to the connected node.
+     * Starts at index 0, untill <code>amount</code> of unspent addresses are found.
      * @param seed      Tryte-encoded seed. It should be noted that this seed is not transferred.
      * @param security  Security level to be used for the private key / address. Can be 1, 2 or 3.
      * @param checksum  Adds 9-tryte address checksum.
@@ -111,7 +112,8 @@ public class IotaAPI extends IotaAPICore {
     }
     
     /**
-     * 
+     * Generates new addresses, meaning addresses which were not spend from, according to the connected node.
+     * Stops when <code>amount</code> of unspent addresses are found,starting from <code>index</code>
      * @param seed      Tryte-encoded seed. It should be noted that this seed is not transferred.
      * @param security  Security level to be used for the private key / address. Can be 1, 2 or 3.
      * @param checksum  Adds 9-tryte address checksum.
@@ -125,7 +127,8 @@ public class IotaAPI extends IotaAPICore {
     }
     
     /**
-     * 
+     * Generates new addresses, meaning addresses which were not spend from, according to the connected node.
+     * Stops when <code>amount</code> of unspent addresses are found,starting from <code>index</code>
      * @param seed      Tryte-encoded seed. It should be noted that this seed is not transferred.
      * @param security  Security level to be used for the private key / address. Can be 1, 2 or 3.
      * @param checksum  Adds 9-tryte address checksum.
@@ -163,7 +166,8 @@ public class IotaAPI extends IotaAPICore {
     }
     
     /**
-     * 
+     * Generates <code>amount</code> of addresses, starting from <code>index</code>
+     * This does not mean that these addresses are safe to use (unspent)
      * @param seed      Tryte-encoded seed. It should be noted that this seed is not transferred.
      * @param security  Security level to be used for the private key / address. Can be 1, 2 or 3.
      * @param checksum  Adds 9-tryte address checksum.

--- a/jota/src/main/java/jota/dto/response/GetNewAddressResponse.java
+++ b/jota/src/main/java/jota/dto/response/GetNewAddressResponse.java
@@ -27,4 +27,12 @@ public class GetNewAddressResponse extends AbstractResponse {
     public List<String> getAddresses() {
         return addresses;
     }
+    
+    /**
+     * Gets the first address, for quick access
+     * @return The address
+     */
+    public String first() {
+        return addresses.get(0);
+    }
 }

--- a/jota/src/test/java/jota/IotaAPITest.java
+++ b/jota/src/test/java/jota/IotaAPITest.java
@@ -128,31 +128,31 @@ public class IotaAPITest {
 
     @Test
     public void shouldCreateANewAddressWithChecksum() throws ArgumentException {
-        final GetNewAddressResponse res1 = iotaAPI.getNewAddress(TEST_SEED1, 1, 0, true, 5, false);
+        final GetNewAddressResponse res1 = iotaAPI.getAddressesUnchecked(TEST_SEED1, 1, true, 0, 5);
         assertThat(res1.getAddresses().get(0), Is.is(TEST_ADDRESS_WITH_CHECKSUM_SECURITY_LEVEL_1));
 
-        final GetNewAddressResponse res2 = iotaAPI.getNewAddress(TEST_SEED1, 2, 0, true, 5, false);
+        final GetNewAddressResponse res2 = iotaAPI.getAddressesUnchecked(TEST_SEED1, 2, true, 0, 5);
         assertThat(res2.getAddresses().get(0), Is.is(TEST_ADDRESS_WITH_CHECKSUM_SECURITY_LEVEL_2));
 
-        final GetNewAddressResponse res3 = iotaAPI.getNewAddress(TEST_SEED1, 3, 0, true, 5, false);
+        final GetNewAddressResponse res3 = iotaAPI.getAddressesUnchecked(TEST_SEED1, 3, true, 0, 5);
         assertThat(res3.getAddresses().get(0), Is.is(TEST_ADDRESS_WITH_CHECKSUM_SECURITY_LEVEL_3));
     }
 
     @Test
     public void shouldCreateANewAddressWithoutChecksum() throws ArgumentException {
-        final GetNewAddressResponse res1 = iotaAPI.getNewAddress(TEST_SEED1, 1, 0, false, 5, false);
+        final GetNewAddressResponse res1 = iotaAPI.getAddressesUnchecked(TEST_SEED1, 1, false, 0, 5);
         assertThat(res1.getAddresses().get(0), Is.is(TEST_ADDRESS_WITHOUT_CHECKSUM_SECURITY_LEVEL_1));
 
-        final GetNewAddressResponse res2 = iotaAPI.getNewAddress(TEST_SEED1, 2, 0, false, 5, false);
+        final GetNewAddressResponse res2 = iotaAPI.getAddressesUnchecked(TEST_SEED1, 2, false, 0, 5);
         assertThat(res2.getAddresses().get(0), Is.is(TEST_ADDRESS_WITHOUT_CHECKSUM_SECURITY_LEVEL_2));
 
-        final GetNewAddressResponse res3 = iotaAPI.getNewAddress(TEST_SEED1, 3, 0, false, 5, false);
+        final GetNewAddressResponse res3 = iotaAPI.getAddressesUnchecked(TEST_SEED1, 3, false, 0, 5);
         assertThat(res3.getAddresses().get(0), Is.is(TEST_ADDRESS_WITHOUT_CHECKSUM_SECURITY_LEVEL_3));
     }
 
     @Test
     public void shouldCreate100Addresses() throws ArgumentException {
-        GetNewAddressResponse res = iotaAPI.getNewAddress(TEST_SEED1, 2, 0, false, 100, false);
+        GetNewAddressResponse res = iotaAPI.getAddressesUnchecked(TEST_SEED1, 2, false, 0, 100);
         assertEquals(res.getAddresses().size(), 100);
     }
 


### PR DESCRIPTION
Fixes the following:
1. The method name is get "New" address, but actually is not.(index maybe reused)
2. You were not able to get 2 new addresses, because the check stops at the first found.

Tests have been adapted to use the new functions.