### PR TITLE
Add owasp dependency check

### DIFF
--- a/jota/pom.xml
+++ b/jota/pom.xml
@@ -100,7 +100,26 @@
             <artifactId>${md-doclet-artifact}</artifactId>
         </dependency>
     </dependencies>
-    
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <configuration>
+                    <skipSystemScope>true</skipSystemScope>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <reporting>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <version.junit5>5.4.0</version.junit5>
         
         <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
+        <dependency-check-maven.version>5.0.0-M3</dependency-check-maven.version>
     </properties>
 
     <modules>
@@ -300,6 +301,11 @@
 	            <artifactId>maven-failsafe-plugin</artifactId>
 	            <version>${version.maven-failsafe-plugin}</version>
 	        </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>${dependency-check-maven.version}</version>
+            </plugin>
         </plugins>
     </build>
     


### PR DESCRIPTION
In order to protect the client from security vulnerabilities coming from 3 party libraries it is necessary to implement dependency check.