### PR TITLE
Make terminology consistent with Go and JS libraries

### DIFF
--- a/docs/iota-java/usableBalance.md
+++ b/docs/iota-java/usableBalance.md
@@ -1,6 +1,6 @@
 
-# [usableBalance](https://github.com/iotaledger/iota-java/blob/master/jota/src/main/java/org/iota/jota/account/Account.java#L82)
- long usableBalance()
+# [availableBalance](https://github.com/iotaledger/iota-java/blob/master/jota/src/main/java/org/iota/jota/account/Account.java#L82)
+ long availableBalance()
 
 Runs the input selection with the CDAs in order to determine the usable balance for funding transfers.
 > **Important note:** This API is currently in Beta and is subject to change. Use of these APIs in production applications is not supported.
@@ -23,7 +23,7 @@ Runs the input selection with the CDAs in order to determine the usable balance 
  Account account = new IotaAccount.Builder().build();
 
 try { 
-    long balance = account.usableBalance();
+    long balance = account.availableBalance();
     
     // Sweep your account balance to 1 address
     Future<ConditionalDepositAddress> response = account.newDepositAddress(nextHour, false, balance);

--- a/jota/src/main/java/org/iota/jota/IotaAccount.java
+++ b/jota/src/main/java/org/iota/jota/IotaAccount.java
@@ -299,8 +299,8 @@ public class IotaAccount implements Account, EventListener {
      * {@inheritDoc}
      */
     @Override
-    public long usableBalance() throws AccountError {
-        return accountManager.getUsableBalance();
+    public long availableBalance() throws AccountError {
+        return accountManager.getAvailableBalance();
     }
 
     /**

--- a/jota/src/main/java/org/iota/jota/account/Account.java
+++ b/jota/src/main/java/org/iota/jota/account/Account.java
@@ -79,7 +79,7 @@ public interface Account extends TaskService {
      * @throws AccountError When we failed to get the balance
      */
     @Document
-    long usableBalance() throws AccountError;
+    long availableBalance() throws AccountError;
     
     /**
      * Uses all stored CDAs to determine the current total balance.

--- a/jota/src/main/java/org/iota/jota/account/AccountStateManager.java
+++ b/jota/src/main/java/org/iota/jota/account/AccountStateManager.java
@@ -142,8 +142,8 @@ public class AccountStateManager {
      * Returns the total balance of addresses which have their deposit conditions fulfilled
      * @return The usable account balance (You are able to send this)
      */
-    public long getUsableBalance() {
-        return inputSelector.getUsableBalance();
+    public long getAvailableBalance() {
+        return inputSelector.getAvailableBalance();
     }
 
     public boolean isNew() {

--- a/jota/src/main/java/org/iota/jota/account/inputselector/InputSelectionStrategy.java
+++ b/jota/src/main/java/org/iota/jota/account/inputselector/InputSelectionStrategy.java
@@ -14,5 +14,5 @@ public interface InputSelectionStrategy {
      */
     List<Input> getInput(long requiredValue, boolean balanceCheck );
 
-    long getUsableBalance();
+    long getAvailableBalance();
 }

--- a/jota/src/main/java/org/iota/jota/account/inputselector/InputSelectionStrategyImpl.java
+++ b/jota/src/main/java/org/iota/jota/account/inputselector/InputSelectionStrategyImpl.java
@@ -55,7 +55,7 @@ public class InputSelectionStrategyImpl extends AccountPlugin implements InputSe
     }
 
     @Override
-    public long getUsableBalance() {
+    public long getAvailableBalance() {
         synchronized(cache) {
             long balance = cache.getStream()
                 .filter(entry -> isUsable(entry.getKey(), entry.getValue())) // remove unwanted inputs

--- a/jota/src/test/java/org/iota/jota/IotaAccountIntegrationTest.java
+++ b/jota/src/test/java/org/iota/jota/IotaAccountIntegrationTest.java
@@ -75,7 +75,7 @@ public class IotaAccountIntegrationTest {
         assertTrue(account.loaded, "Account should be loaded after build");
         assertEquals(TEST_SEED_ID, account.getId(), "Account ID should be set to the seed id ");
         assertTrue(account.isNew(), "Should be a new account");
-        assertEquals(0, account.usableBalance(), "New accounts should have 0 balance");
+        assertEquals(0, account.availableBalance(), "New accounts should have 0 balance");
         assertEquals(0, account.totalBalance(), "New accounts should have 0 balance");
     }
 

--- a/jota/src/test/java/org/iota/jota/IotaAccountTest.java
+++ b/jota/src/test/java/org/iota/jota/IotaAccountTest.java
@@ -60,7 +60,7 @@ public class IotaAccountTest {
         assertTrue(account.loaded, "Account should be loaded after build");
         assertEquals(TEST_SEED_ID, account.getId(), "Account ID should be set to the seed id ");
         assertTrue(account.isNew(), "Should be a new account");
-        assertEquals(0, account.usableBalance(), "New accounts should have 0 balance");
+        assertEquals(0, account.availableBalance(), "New accounts should have 0 balance");
         assertEquals(0, account.totalBalance(), "New accounts should have 0 balance");
     }
 
@@ -75,20 +75,20 @@ public class IotaAccountTest {
         assertTrue(account.loaded, "Account should be loaded after build");
         assertEquals(TEST_SEED_ID, account.getId(), "Account ID should be set to the seed id");
         assertFalse(account.isNew(), "Should not be a new account");
-        assertEquals(0, account.usableBalance(), "Account should have 0 usable balance");
+        assertEquals(0, account.availableBalance(), "Account should have 0 usable balance");
         assertEquals(5, account.totalBalance(), "Account should have 5 total balance");
 
         Date timeOut = new Date(Long.MAX_VALUE);
         ConditionalDepositAddress cda = account.newDepositAddress(timeOut, false, 10).get();
 
-        assertEquals(0, account.usableBalance(), "Account should have 0 usable balance");
+        assertEquals(0, account.availableBalance(), "Account should have 0 usable balance");
         assertEquals(15, account.totalBalance(), "Account should have 15 total balance");
         assertEquals( "GGAOVJJKOHECPAR9GQBFOISLYUXSRXXXPT9GEYBTRBBMTJAN9CMH9EVVRYDGXUTDMECGXKFWPYAXUO9QD", cda.getDepositAddress().getHash(),
                 "Should have generated address at index 5");
     }
 
     @Test
-    void usableBalance() {
+    void availableBalance() {
         // Force CDA to have received
         mockBalance(ADDR_0_SEC_3, 5l);
 
@@ -98,7 +98,7 @@ public class IotaAccountTest {
 
         IotaAccount account = new IotaAccount.Builder(TEST_SEED).mwm(9).store(store).api(MOCK_API).build();
 
-        assertEquals(5, account.usableBalance(), "Account should have 5 usable balance");
+        assertEquals(5, account.availableBalance(), "Account should have 5 usable balance");
         assertEquals(5, account.totalBalance(), "Account should have 5 total balance");
     }
     


### PR DESCRIPTION
The other libraries use the term `AvailableBalance`. Just noticed this while documenting them. It would make it easier if all libraries used the same term for consistency and to avoid confusion between usable and available.

Unless there are some technical reasons for the use of `UsableBalance` that I'm missing.