### PR TITLE
Fix vulnerabilities and update dependencies

### DIFF
--- a/jota/src/main/java/org/iota/jota/store/JsonFlatFileStore.java
+++ b/jota/src/main/java/org/iota/jota/store/JsonFlatFileStore.java
@@ -49,17 +49,15 @@ public class JsonFlatFileStore extends FlatFileStore {
 
     @Override
     protected Map<String, Serializable> loadFromInputStream(InputStream stream){
-        Map<String, Serializable> store;
         try {
-            store = objectMapper.readValue(stream, new TypeReference<Map<String, AccountState>>(){});
+            return objectMapper.readValue(stream, new TypeReference<Map<String, AccountState>>(){});
         } catch (IOException e) {
             if (e.getClass().equals(MismatchedInputException.class)) {
-                store = new HashMap<>();
+                return new HashMap<>();
             } else {
                 throw new RuntimeException(e);
             }
         }
-        return store;
     }
     
     @Override

--- a/jota/src/main/java/org/iota/jota/store/JsonFlatFileStore.java
+++ b/jota/src/main/java/org/iota/jota/store/JsonFlatFileStore.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,11 +36,6 @@ public class JsonFlatFileStore extends FlatFileStore {
         super(location);
         loadJson();
     }
-
-    public JsonFlatFileStore(URI location) {
-        super(location);
-        loadJson();
-    }
     
     private void loadJson() {
         objectMapper = new ObjectMapper();
@@ -50,7 +46,8 @@ public class JsonFlatFileStore extends FlatFileStore {
     @Override
     protected Map<String, Serializable> loadFromInputStream(InputStream stream){
         try {
-            return objectMapper.readValue(stream, new TypeReference<Map<String, AccountState>>(){});
+            return Collections.unmodifiableMap(objectMapper.readValue(stream,
+                    new TypeReference<Map<String, AccountState>>() {}));
         } catch (IOException e) {
             if (e.getClass().equals(MismatchedInputException.class)) {
                 return new HashMap<>();

--- a/pom.xml
+++ b/pom.xml
@@ -95,12 +95,12 @@
         <jadler-all.version>1.3.0</jadler-all.version>
         <zxing.version>3.3.3</zxing.version>
         <javase.version>2.5.0</javase.version>
-        <jackson-databind.version>2.9.10</jackson-databind.version>
+        <jackson-databind.version>2.10.0</jackson-databind.version>
         <mongodb-driver.version>3.4.3</mongodb-driver.version>
         <bson.version>3.5.0</bson.version>
         <junit5.version>5.5.0-M1</junit5.version>
 
-        <dependency-check-maven.version>5.0.0-M3</dependency-check-maven.version>
+        <dependency-check-maven.version>5.2.2</dependency-check-maven.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
 
         <bcprov-jdk15on.version>1.61</bcprov-jdk15on.version>
-        <retrofit.version>2.5.0</retrofit.version>
+        <retrofit.version>2.6.2</retrofit.version>
         <converter-gson.version>2.5.0</converter-gson.version>
         <commons-lang3.version>3.6</commons-lang3.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
@@ -95,7 +95,7 @@
         <jadler-all.version>1.3.0</jadler-all.version>
         <zxing.version>3.3.3</zxing.version>
         <javase.version>2.5.0</javase.version>
-        <jackson-databind.version>2.9.9</jackson-databind.version>
+        <jackson-databind.version>2.9.10</jackson-databind.version>
         <mongodb-driver.version>3.4.3</mongodb-driver.version>
         <bson.version>3.5.0</bson.version>
         <junit5.version>5.5.0-M1</junit5.version>


### PR DESCRIPTION
@kwek20 can you please have a look at `jota/src/main/java/org/iota/jota/store/JsonFlatFileStore.java`

If I update to jackson 2.10.0 I get the following error:

`Error:(53, 42) java: incompatible types: inference variable T has incompatible bounds
    equality constraints: java.util.Map<java.lang.String,org.iota.jota.account.AccountState>
    lower bounds: java.util.Map<java.lang.String,java.io.Serializable>,java.lang.Object`

Why not this:

`return objectMapper.readValue(stream, new TypeReference<Map<String, Serializable>>(){});`