### PR TITLE
Fix: Multisig with other sec levels

### DIFF
--- a/jota/src/main/java/org/iota/jota/utils/Multisig.java
+++ b/jota/src/main/java/org/iota/jota/utils/Multisig.java
@@ -1,11 +1,11 @@
 package org.iota.jota.utils;
 
-import java.util.Arrays;
-
 import org.iota.jota.error.ArgumentException;
 import org.iota.jota.model.Bundle;
 import org.iota.jota.pow.ICurl;
 import org.iota.jota.pow.SpongeFactory;
+
+import java.util.Arrays;
 
 /**
  * @author pinpong
@@ -80,7 +80,7 @@ public class Multisig {
 
     public String getKey(String seed, int index, int security) throws ArgumentException {
 
-        return Converter.trytes(signingInstance.key(Converter.trits(seed, 81 * security), index, security));
+        return Converter.trytes(signingInstance.key(Converter.trits(seed, Constants.HASH_LENGTH_TRITS), index, security));
     }
 
     /**


### PR DESCRIPTION
# Description of change
We couln't use security levels other than 3 in multisig. 
This was due to bug in key calculation causing us to not create enough space for trits with alower sec level.

Fixes #218 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tests pass, added another unit test for sec 1 multisig
