### PR TITLE
Feature: Added isConfirmed alias for getInclusionStates

### DIFF
--- a/jota/src/main/java/org/iota/jota/IotaAPI.java
+++ b/jota/src/main/java/org/iota/jota/IotaAPI.java
@@ -1074,6 +1074,29 @@ public class IotaAPI extends IotaAPICore {
     public GetInclusionStateResponse getLatestInclusion(String... hashes) throws ArgumentException {
         return getInclusionStates(hashes);
     }
+    
+    /**
+     * <p>
+     * Get the inclusion states of a set of transactions.
+     * This is for determining if a transaction was accepted and confirmed by the network or not.
+     * </p>
+     * <p>
+     * This API call returns a list of boolean values in the same order as the submitted transactions.
+     * Boolean values will be <tt>true</tt> for confirmed transactions, otherwise <tt>false</tt>.
+     * </p>
+     * 
+     * This is command does the same as {@link #getInclusionStates(String...)} but a copy exists 
+     * for readability.
+     * 
+     * @param hashes The transaction hashes to check for
+     * @return {@link GetInclusionStateResponse}
+     * @throws ArgumentException when one of the hashes is invalid
+     * @see #getInclusionStates(String...)
+     */
+    @Document
+    public GetInclusionStateResponse isConfirmed(String... hashes) throws ArgumentException {
+        return getInclusionStates(hashes);
+    }
 
     /**
      * Wrapper function: Runs prepareTransfers, as well as attachToTangle.

--- a/jota/src/test/java/org/iota/jota/IotaAPITest.java
+++ b/jota/src/test/java/org/iota/jota/IotaAPITest.java
@@ -8,26 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-
 import org.hamcrest.core.IsNull;
 import org.iota.jota.builder.AddressRequest;
 import org.iota.jota.config.types.FileConfig;
 import org.iota.jota.config.types.IotaDefaultConfig;
-import org.iota.jota.dto.response.BroadcastTransactionsResponse;
-import org.iota.jota.dto.response.CheckConsistencyResponse;
-import org.iota.jota.dto.response.GetAccountDataResponse;
-import org.iota.jota.dto.response.GetBalancesAndFormatResponse;
-import org.iota.jota.dto.response.GetBundleResponse;
-import org.iota.jota.dto.response.GetInclusionStateResponse;
-import org.iota.jota.dto.response.GetNewAddressResponse;
-import org.iota.jota.dto.response.GetNodeInfoResponse;
-import org.iota.jota.dto.response.GetTransferResponse;
-import org.iota.jota.dto.response.GetTrytesResponse;
-import org.iota.jota.dto.response.ReplayBundleResponse;
-import org.iota.jota.dto.response.SendTransferResponse;
+import org.iota.jota.dto.response.*;
 import org.iota.jota.error.ArgumentException;
 import org.iota.jota.model.Input;
 import org.iota.jota.model.Transaction;
@@ -38,6 +23,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
 
 /**
  * Let's do some integration test coverage against a devnet node
@@ -285,8 +274,16 @@ public class IotaAPITest {
 
     @Test
     @Tag("IntegrationTest")
-    public void shouldGetLastInclusionState() throws ArgumentException {
-        GetInclusionStateResponse res = iotaAPI.getLatestInclusion(new String[]{TEST_HASH});
+    public void shouldGetInclusionStates() throws ArgumentException {
+        GetInclusionStateResponse res = iotaAPI.getInclusionStates(new String[]{TEST_HASH});
+        assertThat("States should be an array of booleans", res.getStates(), IsNull.notNullValue());
+        assertTrue(res.getStates()[0], "Hash should have been seen as confirmed");
+    }
+    
+    @Test
+    @Tag("IntegrationTest")
+    public void shouldIsConfirmed() throws ArgumentException {
+        GetInclusionStateResponse res = iotaAPI.isConfirmed(new String[]{TEST_HASH});
         assertThat("States should be an array of booleans", res.getStates(), IsNull.notNullValue());
         assertTrue(res.getStates()[0], "Hash should have been seen as confirmed");
     }


### PR DESCRIPTION
# Description of change
Adds a synonym/alias for calling getInclusionStates to make it easier to understand what happenshen you call this function.

Fixes #216.

## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Added a unit test

## Change checklist

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
