### PR TITLE
Fix: Allow file in host/url

### DIFF
--- a/jota/src/main/java/org/iota/jota/IotaAPICore.java
+++ b/jota/src/main/java/org/iota/jota/IotaAPICore.java
@@ -1,38 +1,18 @@
 package org.iota.jota;
 
+import static org.iota.jota.utils.Constants.INVALID_ADDRESSES_INPUT_ERROR;
+import static org.iota.jota.utils.Constants.INVALID_APPROVE_DEPTH_ERROR;
+import static org.iota.jota.utils.Constants.INVALID_ATTACHED_TRYTES_INPUT_ERROR;
+import static org.iota.jota.utils.Constants.INVALID_BUNDLE_HASH_ERROR;
+import static org.iota.jota.utils.Constants.INVALID_HASHES_INPUT_ERROR;
+import static org.iota.jota.utils.Constants.INVALID_TAG_INPUT_ERROR;
+import static org.iota.jota.utils.Constants.INVALID_THRESHOLD_ERROR;
+import static org.iota.jota.utils.Constants.INVALID_TRYTES_INPUT_ERROR;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.iota.jota.connection.Connection;
-import org.iota.jota.dto.request.IotaAttachToTangleRequest;
-import org.iota.jota.dto.request.IotaBroadcastTransactionRequest;
-import org.iota.jota.dto.request.IotaCheckConsistencyRequest;
-import org.iota.jota.dto.request.IotaCommandRequest;
-import org.iota.jota.dto.request.IotaCustomRequest;
-import org.iota.jota.dto.request.IotaFindTransactionsRequest;
-import org.iota.jota.dto.request.IotaGetBalancesRequest;
-import org.iota.jota.dto.request.IotaGetInclusionStateRequest;
-import org.iota.jota.dto.request.IotaGetTransactionsToApproveRequest;
-import org.iota.jota.dto.request.IotaGetTrytesRequest;
-import org.iota.jota.dto.request.IotaNeighborsRequest;
-import org.iota.jota.dto.request.IotaStoreTransactionsRequest;
-import org.iota.jota.dto.request.IotaWereAddressesSpentFromRequest;
-import org.iota.jota.dto.response.AddNeighborsResponse;
-import org.iota.jota.dto.response.BroadcastTransactionsResponse;
-import org.iota.jota.dto.response.CheckConsistencyResponse;
-import org.iota.jota.dto.response.FindTransactionResponse;
-import org.iota.jota.dto.response.GetAttachToTangleResponse;
-import org.iota.jota.dto.response.GetBalancesResponse;
-import org.iota.jota.dto.response.GetInclusionStateResponse;
-import org.iota.jota.dto.response.GetNeighborsResponse;
-import org.iota.jota.dto.response.GetNodeAPIConfigurationResponse;
-import org.iota.jota.dto.response.GetNodeInfoResponse;
-import org.iota.jota.dto.response.GetTipsResponse;
-import org.iota.jota.dto.response.GetTransactionsToApproveResponse;
-import org.iota.jota.dto.response.GetTrytesResponse;
-import org.iota.jota.dto.response.InterruptAttachingToTangleResponse;
-import org.iota.jota.dto.response.IotaCustomResponse;
-import org.iota.jota.dto.response.RemoveNeighborsResponse;
-import org.iota.jota.dto.response.StoreTransactionsResponse;
-import org.iota.jota.dto.response.WereAddressesSpentFromResponse;
+import org.iota.jota.dto.request.*;
+import org.iota.jota.dto.response.*;
 import org.iota.jota.error.ArgumentException;
 import org.iota.jota.model.Transaction;
 import org.iota.jota.pow.ICurl;
@@ -43,21 +23,7 @@ import org.iota.mddoclet.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-
-import static org.iota.jota.utils.Constants.INVALID_ADDRESSES_INPUT_ERROR;
-import static org.iota.jota.utils.Constants.INVALID_APPROVE_DEPTH_ERROR;
-import static org.iota.jota.utils.Constants.INVALID_ATTACHED_TRYTES_INPUT_ERROR;
-import static org.iota.jota.utils.Constants.INVALID_BUNDLE_HASH_ERROR;
-import static org.iota.jota.utils.Constants.INVALID_HASHES_INPUT_ERROR;
-import static org.iota.jota.utils.Constants.INVALID_TAG_INPUT_ERROR;
-import static org.iota.jota.utils.Constants.INVALID_THRESHOLD_ERROR;
-import static org.iota.jota.utils.Constants.INVALID_TRYTES_INPUT_ERROR;
+import java.util.*;
 
 /**
  * This class provides access to the Iota core API
@@ -118,7 +84,7 @@ public class IotaAPICore {
                 return started;
             }
         } catch (Exception e) {
-            log.warn("Failed to add node connection to pool due to " + e.getMessage());
+            log.warn("Failed to add node connection to pool due to \"" + e.getMessage() + "\"");
             return false;
         }
     }

--- a/jota/src/main/java/org/iota/jota/builder/ApiBuilder.java
+++ b/jota/src/main/java/org/iota/jota/builder/ApiBuilder.java
@@ -84,7 +84,15 @@ public abstract class ApiBuilder<T extends ApiBuilder<T, E>, E extends IotaAPICo
         }
         
         if (hasLegacyOptions()) {
-            nodes.add(new HttpConnector(protocol,  host,  port, timeout));
+            String path = "";
+            //Fix for a path, crude but works!
+            if (host.contains("/")) {
+                System.out.println(host);
+                path = host.substring(host.indexOf("/"));
+                host = host.substring(0, host.indexOf("/"));
+            }
+            
+            nodes.add(new HttpConnector(protocol,  host,  port, path, timeout));
         }
         
         return (T) this;

--- a/jota/src/main/java/org/iota/jota/builder/ApiBuilder.java
+++ b/jota/src/main/java/org/iota/jota/builder/ApiBuilder.java
@@ -1,10 +1,5 @@
 package org.iota.jota.builder;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.iota.jota.IotaAPICore;
 import org.iota.jota.IotaPoW;
 import org.iota.jota.config.options.ApiConfig;
@@ -16,6 +11,11 @@ import org.iota.jota.pow.ICurl;
 import org.iota.jota.pow.SpongeFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 
 @SuppressWarnings("unchecked")
 public abstract class ApiBuilder<T extends ApiBuilder<T, E>, E extends IotaAPICore> 
@@ -47,6 +47,7 @@ public abstract class ApiBuilder<T extends ApiBuilder<T, E>, E extends IotaAPICo
      * @return The builder
      * @throws Exception When we failed to load env configs or a url was malformed
      */
+    @Override
     @SuppressWarnings("deprecation")
     protected T generate() throws Exception {
         for (ApiConfig config : getConfigs()) {
@@ -73,7 +74,8 @@ public abstract class ApiBuilder<T extends ApiBuilder<T, E>, E extends IotaAPICo
                 
                 // Now if we had a legacy config node, we wont take the default node
                 // BUt if nothing was configured, we add the legacy node from default config
-                if (config.hasNodes() && (!(config instanceof IotaDefaultConfig) || !hasLegacyOptions())) {
+                if (config.hasNodes() && (
+                        !(config instanceof IotaDefaultConfig) || !(hasLegacyOptions() || hasNodes()))){
                     for (Connection c : config.getNodes()) {
                         nodes.add(c);
                     }
@@ -82,7 +84,7 @@ public abstract class ApiBuilder<T extends ApiBuilder<T, E>, E extends IotaAPICo
         }
         
         if (hasLegacyOptions()) {
-            nodes.add(new HttpConnector(protocol, host, port, timeout));
+            nodes.add(new HttpConnector(protocol,  host,  port, timeout));
         }
         
         return (T) this;
@@ -160,10 +162,12 @@ public abstract class ApiBuilder<T extends ApiBuilder<T, E>, E extends IotaAPICo
         return port;
     }
 
+    @Override
     public IotaPoW getLocalPoW() {
         return localPoW;
     }
 
+    @Override
     public ICurl getCustomCurl() {
         return customCurl;
     }
@@ -172,7 +176,13 @@ public abstract class ApiBuilder<T extends ApiBuilder<T, E>, E extends IotaAPICo
         nodes.add(c);
         return (T) this;
     }
+    
+    public T addHttpNode(Connection c) {
+        nodes.add(c);
+        return (T) this;
+    }
 
+    @Override
     public List<Connection> getNodes() {
         return nodes;
     }

--- a/jota/src/test/java/org/iota/jota/IotaAPITest.java
+++ b/jota/src/test/java/org/iota/jota/IotaAPITest.java
@@ -9,9 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.hamcrest.core.IsNull;
+import org.iota.jota.IotaAPI.Builder;
 import org.iota.jota.builder.AddressRequest;
 import org.iota.jota.config.types.FileConfig;
 import org.iota.jota.config.types.IotaDefaultConfig;
+import org.iota.jota.connection.HttpConnector;
 import org.iota.jota.dto.response.*;
 import org.iota.jota.error.ArgumentException;
 import org.iota.jota.model.Input;
@@ -24,6 +26,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -82,7 +85,25 @@ public class IotaAPITest {
         iotaAPI = new IotaAPI.Builder().config(new FileConfig()).localPoW(new PearlDiverLocalPoW()).build();
         assertNotNull(iotaAPI, "An API should have been created");
     }
-
+    
+    @Test
+    public void shouldAcceptUrlAsNode() throws MalformedURLException {
+        Builder builder = new IotaAPI.Builder();
+        IotaAPI api;
+        
+        builder.addNode(new HttpConnector("https://iota.net:14265/node/"));
+        assertEquals(builder.getNodes().size(), 1, "URL should have been accepted");
+        api = builder.build();
+        assertFalse(api.nodes.isEmpty(), "API should be created succesfully");
+        
+        builder = new IotaAPI.Builder();
+        
+        builder.addNode(new HttpConnector("https", "iota.net", 14265, "/node/"));
+        assertEquals(builder.getNodes().size(), 1, "URL should have been accepted");
+        api = builder.build();
+        assertFalse(api.nodes.isEmpty(), "API should be created succesfully");
+    }
+    
     @SuppressWarnings("deprecation")
     @Test
     public void shouldCreateIotaApiProxyInstanceWithDefaultValues() {

--- a/jota/src/test/java/org/iota/jota/IotaAPITest.java
+++ b/jota/src/test/java/org/iota/jota/IotaAPITest.java
@@ -90,6 +90,13 @@ public class IotaAPITest {
     public void shouldAcceptUrlAsNode() throws MalformedURLException {
         Builder builder = new IotaAPI.Builder();
         IotaAPI api;
+
+        builder.host("iota.net/node/", false);
+        assertEquals(builder.getHost(), "iota.net/node/", "Host should have been accepted");
+        api = builder.build();
+        assertFalse(api.nodes.isEmpty(), "API should be created succesfully");
+
+        builder = new IotaAPI.Builder();
         
         builder.addNode(new HttpConnector("https://iota.net:14265/node/"));
         assertEquals(builder.getNodes().size(), 1, "URL should have been accepted");


### PR DESCRIPTION
# Description of change

Adds support for a path in the host url; `iota.net/node/` -> /node/ is the "file"
Fixes #224 

Added tests here: `IotaAPITest.shouldAcceptUrlAsNode`

Issue was URL ordering; port goes in between host and file (iota.net:14265/node/)

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
Tested with url provided in the bug report

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests using ginkgo that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
